### PR TITLE
Update AI Week dates from April 5-11 to April 11-18

### DIFF
--- a/ai-week/index.html
+++ b/ai-week/index.html
@@ -1078,7 +1078,7 @@ footer {
   <div class="hero-bg-grid"></div>
   <div class="hero-glow"></div>
   <div class="container hero-content">
-    <div class="hero-eyebrow">April 5–11, 2026 · Baton Rouge, LA</div>
+    <div class="hero-eyebrow">April 11–18, 2026 · Baton Rouge, LA</div>
     <h1 class="hero-title">AI <em>Week</em></h1>
     <p class="hero-subtitle">Seven days of workshops, keynotes, and hands-on labs exploring how artificial intelligence is reshaping industries — from software engineering to small business to everyday life.</p>
     <div class="hero-meta">
@@ -1224,8 +1224,8 @@ footer {
     <!-- Day 1 -->
     <div class="schedule-day reveal">
       <div class="schedule-day-header">
-        <div class="schedule-day-name">Sunday</div>
-        <div class="schedule-day-date">APR 5</div>
+        <div class="schedule-day-name">Saturday</div>
+        <div class="schedule-day-date">APR 11</div>
       </div>
       <div class="schedule-item">
         <div class="schedule-time">4:00 PM</div>
@@ -1248,8 +1248,8 @@ footer {
     <!-- Day 2 -->
     <div class="schedule-day reveal">
       <div class="schedule-day-header">
-        <div class="schedule-day-name">Monday</div>
-        <div class="schedule-day-date">APR 6</div>
+        <div class="schedule-day-name">Sunday</div>
+        <div class="schedule-day-date">APR 12</div>
       </div>
       <div class="schedule-item">
         <div class="schedule-time">9:00 AM</div>
@@ -1288,8 +1288,8 @@ footer {
     <!-- Day 3 -->
     <div class="schedule-day reveal">
       <div class="schedule-day-header">
-        <div class="schedule-day-name">Tuesday</div>
-        <div class="schedule-day-date">APR 7</div>
+        <div class="schedule-day-name">Monday</div>
+        <div class="schedule-day-date">APR 13</div>
       </div>
       <div class="schedule-item">
         <div class="schedule-time">9:00 AM</div>
@@ -1328,8 +1328,8 @@ footer {
     <!-- Day 4 -->
     <div class="schedule-day reveal">
       <div class="schedule-day-header">
-        <div class="schedule-day-name">Wednesday</div>
-        <div class="schedule-day-date">APR 8</div>
+        <div class="schedule-day-name">Tuesday</div>
+        <div class="schedule-day-date">APR 14</div>
       </div>
       <div class="schedule-item">
         <div class="schedule-time">9:00 AM</div>
@@ -1368,8 +1368,8 @@ footer {
     <!-- Day 5 -->
     <div class="schedule-day reveal">
       <div class="schedule-day-header">
-        <div class="schedule-day-name">Thursday</div>
-        <div class="schedule-day-date">APR 9</div>
+        <div class="schedule-day-name">Wednesday</div>
+        <div class="schedule-day-date">APR 15</div>
       </div>
       <div class="schedule-item">
         <div class="schedule-time">9:00 AM</div>
@@ -1408,8 +1408,8 @@ footer {
     <!-- Day 6 -->
     <div class="schedule-day reveal">
       <div class="schedule-day-header">
-        <div class="schedule-day-name">Friday</div>
-        <div class="schedule-day-date">APR 10</div>
+        <div class="schedule-day-name">Thursday</div>
+        <div class="schedule-day-date">APR 16</div>
       </div>
       <div class="schedule-item">
         <div class="schedule-time">9:00 AM</div>
@@ -1448,8 +1448,8 @@ footer {
     <!-- Day 7 -->
     <div class="schedule-day reveal">
       <div class="schedule-day-header">
-        <div class="schedule-day-name">Saturday</div>
-        <div class="schedule-day-date">APR 11</div>
+        <div class="schedule-day-name">Friday</div>
+        <div class="schedule-day-date">APR 17</div>
       </div>
       <div class="schedule-item">
         <div class="schedule-time">10:00 AM</div>


### PR DESCRIPTION
Shifts the entire 7-day schedule forward by 6 days, updating
the hero banner date range, all individual schedule day dates,
and corresponding day-of-week names.

https://claude.ai/code/session_01Y7YfQeH2NuAh26vrorKatg