### PR TITLE
Fix Plex hero logo centering and oversize on mobile

### DIFF
--- a/plex/img/plex-logo.svg
+++ b/plex/img/plex-logo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 26.2.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="plex-logo" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 148 68.2" style="enable-background:new 0 0 148 68.2;" xml:space="preserve">
+	 width="148" height="68.2" viewBox="0 0 148 68.2" style="enable-background:new 0 0 148 68.2;" xml:space="preserve">
 <style type="text/css">
 	.st0{fill:#FFFFFF;}
 	.st1{fill:#EBAF00;}

--- a/plex/index.html
+++ b/plex/index.html
@@ -158,10 +158,10 @@ img, svg {
 }
 
 .hero-logo {
-  display: inline-block;
+  display: block;
   width: 124px;
   height: auto;
-  margin-bottom: 2.5rem;
+  margin: 0 auto 2.5rem;
   filter: drop-shadow(0 8px 32px rgba(235, 175, 0, 0.25));
 }
 


### PR DESCRIPTION
## Summary

The Plex wordmark in the `/plex/` hero rendered oversized and left-aligned on mobile Safari (and a few other browsers), breaking the centered hero composition. Two minimal fixes:

- **`plex/img/plex-logo.svg`** — added explicit `width="148"` and `height="68.2"` attributes. Without intrinsic dimensions on the SVG, mobile Safari ignores the `width` attribute on the `<img>` tag and fills its container.
- **`plex/index.html`** — `.hero-logo` switched from `display: inline-block` (relying on parent `text-align: center`) to `display: block; margin: 0 auto` — the canonical bulletproof way to center an image regardless of how its intrinsic sizing resolves.

+3 / −3 across 2 files.

## Test plan

- [ ] `bundle exec jekyll serve` and load `http://localhost:4000/plex/` on mobile (or in mobile-sized DevTools)
- [ ] Confirm the Plex wordmark sits centered above the "YOU'RE INVITED" pill at ~124px wide
- [ ] After merge, reload `https://joshferrara.com/plex/` on a phone

https://claude.ai/code/session_01BoSjN7A9zfXVCtntewHcEV

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoSjN7A9zfXVCtntewHcEV)_